### PR TITLE
Add fix for issue #25332

### DIFF
--- a/settings/ChangePassword/Controller.php
+++ b/settings/ChangePassword/Controller.php
@@ -45,6 +45,11 @@ class Controller {
 			\OC_JSON::error(array("data" => array("message" => $l->t("Wrong password")) ));
 			exit();
 		}
+        if ($oldPassword == $password) {
+            $l = new \OC_L10n('settings');
+			\OC_JSON::error(array("data" => array("message" => $l->t("The new password can not be the same as the previous one")) ));
+			exit();
+        }
 		if (!is_null($password) && \OC_User::setPassword($username, $password)) {
 			\OC::$server->getUserSession()->updateSessionTokenPassword($password);
 			\OC_JSON::success();


### PR DESCRIPTION
Make sure that the newly entered password is not the same as the
existing password. This is done using a simple if statement comparing
already defined variables for the newly entered and the old password. If
the variables are the same a fitting error will be passed.